### PR TITLE
Guard pyperclip import/patch

### DIFF
--- a/jupyter-clipboard/main.js
+++ b/jupyter-clipboard/main.js
@@ -50,6 +50,12 @@ def copy(x):
     comm.send(x)
 
 try:
+    import pyperclip
+    pyperclip.copy = copy
+except ImportError:
+    pass
+
+try:
     import pandas.io.clipboard # has its own fork of pyperclip
     pandas.io.clipboard.copy = copy
     pandas.io.clipboard.clipboard_set = copy

--- a/jupyter-clipboard/main.js
+++ b/jupyter-clipboard/main.js
@@ -44,12 +44,10 @@ define([
         }
         Jupyter.notebook.kernel.execute(`
 from ipykernel.comm import Comm
-import pyperclip
 
 comm = Comm(target_name='jupyter-clipboard')
 def copy(x):
     comm.send(x)
-pyperclip.copy = copy
 
 try:
     import pandas.io.clipboard # has its own fork of pyperclip


### PR DESCRIPTION
I am getting an exception when importing `pyperclip`.  Tried it with `jupyter=1.0.0`. 